### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/dockerimage.yml
+++ b/.github/workflows/dockerimage.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Build the Docker image
         run: docker build . -t docker.pkg.github.com/antoine-gannat/student-fridge/student-fridge:latest
       - name: Publish to Registry
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: antoine-gannat/student-fridge/student-fridge:latest
           username: ${{ secrets.docker_username }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore